### PR TITLE
Fix default window attributes that lead to all app menus not working.

### DIFF
--- a/WindowMaker/Defaults/WMWindowAttributes.in
+++ b/WindowMaker/Defaults/WMWindowAttributes.in
@@ -3,5 +3,5 @@
   Logo.WMPanel = {Icon = GNUstep.#extension#;};
   Logo.WMClip = {Icon = clip.#extension#;};
   WMDrawer = {Icon = Drawer.#extension#;};
-  "*" = {Icon = defaultAppIcon.#extension#;SharedAppIcon = Yes;};
+  "*" = {Icon = defaultAppIcon.#extension#;};
 }


### PR DESCRIPTION
This patch fixes an error with the default WMWindowAttributes configuration which lead to disabling app menu support for _all_ windows. This default configuration is currently used in FreeBSD, NetBSD, and OpenBSD but prominently overriden in Debian-based Linux systems (which therefore ship with working app menu support).